### PR TITLE
✨ feat(blog): Add Node.js 24 installation guide and refactor blog conventions

### DIFF
--- a/.gemini/commands/blog/refine.toml
+++ b/.gemini/commands/blog/refine.toml
@@ -26,13 +26,16 @@ The blog has two language versions: English and Spanish. You will be given the c
         *   Alter code blocks (` ``` `).
 
 3.  **Language-Specific Instructions:**
-    *   **English:** Apply standard English (US) proofreading rules. {{ args }}
-    *   **Spanish:** Apply standard Castilian Spanish (español de España es-ES) proofreading rules. {{ args }}
+    *   **English:** Apply standard English (US) proofreading rules.
+    *   **Spanish:** Apply standard Castilian Spanish (español de España es-ES) proofreading rules.
 
 4.  **Execution:**
     *   Carefully read the content for both language versions.
     *   Apply only the necessary corrections as defined above.
     *   Preserve the original frontmatter and code blocks.
+
+5. **Other instructions:**
+{{ args }}
 
 5.  **Final Output:**
     Modify the blog posts for both the English and Spanish markdown files. If no changes are needed for a file, tell the user that the post are fine and no changes are needed.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -46,45 +46,12 @@ This project has a set of well-defined conventions that I will strictly follow. 
   - **Translation Files:** When working with i18n, the translation files are located at:
     - **English:** `apps/angelblanco.dev/i18n/locales/en.yaml`
     - **Spanish:** `apps/angelblanco.dev/i18n/locales/es.yaml`
+- **[Blog Post Conventions](./packages/conventions/blog.md):** This guide covers the standards for writing and editing blog posts, including tone, style, language synchronization, and how to use `automd` to embed file content.
 - **[Nuxt Testing Conventions](./packages/conventions/nuxt-testing.md):** This document outlines the conventions for testing Nuxt applications, including unit and component testing strategies.
 - **[Playwright E2E Testing Conventions](./packages/conventions/playwright.md):** This guide covers the standards for writing Playwright E2E tests, emphasizing iteration over all locales and themes and the use of shared utility functions.
 - **[Gemini Commands Conventions](./packages/conventions/gemini-commands.md):** This document explains how to create custom, project-specific commands using `.toml` files located in the `.gemini/commands/` directory.
 
 **Note:** When a new convention file is added to the `packages/conventions` directory, I must add a short summary of it to this section.
-
-## Blog Post Conventions
-
-When writing or editing blog posts, I will adhere to the following guidelines, derived from the project's command configurations.
-
-### General Rules
-
-- **Audience:** The target audience is full-stack developers.
-- **Tone:** Professional yet approachable and engaging. The content should be clear, and a touch of humor is welcome.
-- **SEO & Linking:** I must include relevant external links to high-authority sources, such as the official documentation for any mentioned technologies (e.g., Nuxt, Tailwind CSS).
-- **Titles:** Markdown titles must use sentence case, not title case (e.g., `# My new blog post` instead of `# My New Blog Post`).
-
-### Language Synchronization (English & Spanish)
-
-- **Core Concepts:** The main ideas and structure must be consistent across both English and Spanish versions.
-- **Spanish Adaptation:** The Spanish post is not a literal translation. It must be an idiomatic adaptation for a tech audience from Spain (Castilian Spanish).
-- **Technical Terms:**
-  - Code blocks (`...`) must be identical in both posts and written in English.
-  - Comments within code blocks in the Spanish post must be translated to Spanish.
-  - Common English technical terms (e.g., "commit", "deploy", "frontend") should be kept in English within the Spanish prose, as they are the industry standard.
-
-### Frontmatter
-
-I must generate valid YAML frontmatter for both posts.
-
-```yaml
----
-title: string (min 10 characters)
-tags: string[] (min 1 tag)
-image: string (optional, path to a relevant image, e.g., /images/blog/post-name/hero.webp)
-date: YYYY-MM-DD
-toc: boolean (optional, if false the post will not have a table of contents)
----
-```
 
 ## My Workflow
 

--- a/apps/angelblanco.dev/automd.config.ts
+++ b/apps/angelblanco.dev/automd.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'automd';
+
+const config: Config = {
+  input: [
+    'content/**/*.md',
+  ],
+};
+
+export default config;

--- a/apps/angelblanco.dev/content/blog/0002.install-node-24-on-ubuntu-24.md
+++ b/apps/angelblanco.dev/content/blog/0002.install-node-24-on-ubuntu-24.md
@@ -1,0 +1,217 @@
+---
+title: 'Install Node.js 24 on Ubuntu 24'
+tags:
+  - nodejs
+  - ubuntu
+  - javascript
+  - bash
+  - script
+date: 2025-10-12
+---
+
+Getting Node.js 24 running on Ubuntu 24 should be a straightforward process. While Ubuntu comes with a version of Node.js in its default repositories, you might want to use Node.js 24, which will be LTS in October 2025. This guide offers two simple methods to get you set up quickly.
+
+We'll cover a one-liner script that automates everything, including setting up a proper global prefix for npm and enabling [Yarn](https://yarnpkg.com/) and [pnpm](https://pnpm.io/) via Corepack. For those who prefer manual control, we'll also walk through each step in detail.
+
+### The easy way
+
+I've created a script, so you can install everything by running a single command. This script will set up Node.js 24, configure a global npm prefix (so you don't need `sudo` for global packages), and optionally enable `corepack` (for Yarn and pnpm) and install Bun.
+
+Just open your terminal and run this:
+
+```bash
+curl -fsSL https://angelblanco.dev/scripts/ubuntu-install-node-24.sh | bash
+```
+
+The script will ask for confirmation at each major step, so you still have control over what gets installed. You can also review the [full script content](#the-script) before running it or customize it for your own needs.
+
+If you dont have `curl` installed:
+
+```bash
+sudo apt update
+sudo apt instal curl
+```
+
+### The step-by-step guide
+
+For those who prefer a hands-on approach, here’s a breakdown of what the script does. You can follow these steps to perform the installation manually.
+
+#### 1. Update dependencies and add the NodeSource repository
+
+First, we need to make sure our system has the necessary tools to fetch and install Node.js.
+
+```bash
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg
+```
+
+Next, we'll add the [NodeSource](https://nodesource.com/) repository, which is a trusted source for up-to-date Node.js versions on Debian and Ubuntu.
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+```
+
+#### 2. Install Node.js and npm
+
+With the repository in place, installing Node.js is as simple as running:
+
+```bash
+sudo apt-get install -y nodejs
+```
+
+This command installs both the `node` runtime and the `npm` package manager.
+
+#### 3. Configure npm's global prefix
+
+By default, `npm` installs global packages in a system directory that requires `sudo`. This can lead to permission issues down the line. To avoid this, it's a best practice to configure a local directory for your global packages.
+
+```bash
+mkdir -p ~/.npm-global
+npm config set prefix '~/.npm-global'
+```
+
+You'll also need to add this directory to your `PATH`. Open your `~/.bashrc` or `~/.zshrc` file and add the following line:
+
+```bash
+export PATH=~/.npm-global/bin:$PATH
+```
+
+#### 4. Enable Corepack (for Yarn and pnpm)
+
+[Corepack](https://nodejs.org/api/corepack.html) is an experimental tool included with Node.js that simplifies managing different package managers. With it, you don't need to install [Yarn](https://yarnpkg.com/) or [pnpm](https://pnpm.io/) manually.
+
+To enable it, just run:
+
+```bash
+sudo corepack enable
+```
+
+Now you can use `yarn` and `pnpm` in your projects without any extra installation steps.
+
+#### 5. Install Bun (optional)
+
+[Bun](https://bun.sh/) is a fast, all-in-one JavaScript toolkit that has been gaining a lot of traction. If you want to give it a try, you can install it with its official script:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+### The script
+
+This is the complete script that automates the steps above. It includes confirmations and handles temporary files, making the process smooth and safe.
+
+<!-- automd:file src="../../public/scripts/ubuntu-install-node-24.sh" code lang="bash" -->
+
+```bash [ubuntu-install-node-24.sh]
+#!/bin/bash
+#
+# Author: Ángel Blanco
+# License: MIT
+#
+# This script is provided "as is", without warranty of any kind. Use at your own risk.
+#
+# Source: https://angelblanco.dev/blog/install-node-24-on-ubuntu-24
+#
+# Usage:
+#   curl -fsSL https://angelblanco.dev/scripts/ubuntu-install-node-24.sh | bash
+#
+# This file set up installation of Node JS and several package managers.
+# Normally you will call it from your non-root user, elevated permisson
+# will be granted with sudo.
+#
+
+set -e
+
+# Basic confirmation module before executing the script.
+confirm_action() {
+    read -p "$1 (y/n): " choice
+    case "$choice" in
+        [Yy]|[Yy][Ee][Ss])
+            return 0
+            ;;
+        [Nn]|[Nn][Oo])
+            return 1
+            ;;
+        *)
+            echo "Invalid choice. Please enter 'y' or 'n'."
+            confirm_action "$1"
+            ;;
+    esac
+}
+
+# You can configure this variables if needed
+NODE_VERSION=24
+NPM_PREFIX="~/.npm-global"
+DEPS="ca-certificates curl gnupg"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+TMP_DIR=$SCRIPT_DIR/tmp
+
+echo "This script will install Node.js and optionally other package managers."
+echo ""
+
+if ! confirm_action "Install Node.js version $NODE_VERSION?"; then
+    echo "Skipping Node.js installation. Exiting."
+    exit 0
+fi
+
+echo "Installing deps needed for installing node.js..."
+
+sudo apt update
+sudo apt install -y $DEPS
+
+echo "Installing node JS"
+mkdir -p $TMP_DIR
+curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x -o $TMP_DIR/nodesource_setup.sh
+sudo -E bash $TMP_DIR/nodesource_setup.sh
+
+sudo apt-get install -y nodejs
+
+mkdir -p ~/.npm-global
+npm config set prefix $NPM_PREFIX
+echo "Npm prefix set to $NPM_PREFIX"
+
+echo "Node.js installation completed."
+echo "Node version: "
+node --version
+
+echo ""
+
+if confirm_action "Enable Yarn and pnpm via corepack?"; then
+    echo "Enabling corepack..."
+    sudo corepack enable
+    echo "Corepack enabled."
+    echo "Yarn version: "
+    yarn --version
+    echo "PNPM version: "
+    pnpm --version
+fi
+
+echo ""
+
+if confirm_action "Install Bun?"; then
+    echo "Installing Bun..."
+    curl -fsSL https://bun.sh/install | bash
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    echo "Bun installation completed."
+    bun --version
+fi
+
+echo ""
+echo "Installation process finished."
+echo ""
+echo "You probably want to add global npm bin directory to your path on your .bashrc or .zshrc, to do so, include this line"
+echo 'export PATH=~/.npm-global/bin:$PATH'
+echo ""
+echo "If you wanto to remove the files downloaded in this process please execute"
+echo "rm -rf $TMP_DIR"
+```
+
+<!-- /automd -->
+
+### What about NVM?
+
+[Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) is a fantastic tool for managing multiple Node.js versions. However, I personally prefer to stick to a single, system-wide installation of the latest LTS version. This approach forces me to keep my projects updated. Besides, Node.js rarely introduces major breaking changes in its LTS releases, so the upgrade process is usually straightforward.
+
+If you prefer the flexibility of NVM, you can still use it, but you would likely choose one method or the other. After installing NVM, you would manage your package managers like `yarn` and `pnpm` by installing them globally via `npm` for each Node version you use. You could then use aliases to switch between different versions of your tools. Be aware that this can sometimes lead to path conflicts or unexpected behavior, so be mindful of which versions are active in your shell.

--- a/apps/angelblanco.dev/content/es/blog/0002.install-node-24-on-ubuntu-24.md
+++ b/apps/angelblanco.dev/content/es/blog/0002.install-node-24-on-ubuntu-24.md
@@ -1,0 +1,212 @@
+---
+title: 'Instalar Node.js 24 en Ubuntu 24'
+tags:
+  - nodejs
+  - ubuntu
+  - javascript
+  - bash
+  - script
+date: 2025-10-12
+---
+
+Instalar Node.js 24 en Ubuntu 24 debería ser un proceso sencillo. Aunque Ubuntu incluye una versión de Node.js en sus repositorios por defecto, es posible que quieras utilizar una versión más reciente, como Node.js 24, que será LTS en octubre de 2025. En esta guía te enseño dos métodos para que lo tengas listo rápidamente.
+
+Veremos un script de una sola línea que lo automatiza todo, incluyendo la configuración de npm necesaría para instalar herramientas globales sin permisos de administrador, la activación de [Yarn](https://yarnpkg.com/) y [pnpm](https://pnpm.io/) usando Corepack.
+
+Si quieres personalizar la instalación, también veremos cómo hacerlo paso por paso en detalle.
+
+### La vía fácil
+
+Si tienes prisa puedes instalarlo todo con un el siguiente comando. He preparado un script que se encargará de instalar Node.js 24, configurar npm (para que no necesites `sudo` al instalar paquetes globales) y, opcionalmente, habilitar `corepack` (para Yarn y pnpm) e instalar Bun.
+
+Simplemente abre tu terminal y ejecuta esto:
+
+```bash
+curl -fsSL https://angelblanco.dev/scripts/ubuntu-install-node-24.sh | bash
+```
+
+El script te pedirá confirmación en cada paso importante, así que seguirás teniendo el control sobre lo que se instala. Por supuesto, puedes revisar el [contenido completo del script en este post](#el-script), o en la propia URL antes de ejecutarlo.
+
+### La guía paso a paso
+
+Para quienes prefieren un enfoque más manual, aquí tienes un desglose de lo que hace el script. Puedes seguir estos pasos para realizar la instalación por tu cuenta.
+
+#### 1. Actualizar dependencias y añadir el repositorio de NodeSource
+
+Primero, tenemos que asegurarnos de que nuestro sistema tiene las herramientas necesarias para descargar e instalar Node.js.
+
+```bash
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg
+```
+
+A continuación, añadiremos el repositorio de [NodeSource](https://nodesource.com/), que es una fuente de confianza para obtener versiones actualizadas de Node.js en Debian y Ubuntu.
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+```
+
+#### 2. Instalar Node.js y npm
+
+Con el repositorio ya configurado, instalar Node.js es tan sencillo como ejecutar:
+
+```bash
+sudo apt-get install -y nodejs
+```
+
+Este comando instala tanto el entorno de ejecución `node` como el gestor de paquetes `npm`.
+
+#### 3. Configurar el prefijo global de npm
+
+Por defecto, `npm` instala los paquetes globales en un directorio del sistema que requiere `sudo`. Esto puede provocar problemas de permisos más adelante. Para evitarlo, es una buena práctica configurar un directorio local para tus paquetes globales.
+
+```bash
+mkdir -p ~/.npm-global
+npm config set prefix '~/.npm-global'
+```
+
+También necesitarás añadir este directorio a tu `PATH`. Abre tu fichero `~/.bashrc` o `~/.zshrc` y añade la siguiente línea:
+
+```bash
+export PATH=~/.npm-global/bin:$PATH
+```
+
+#### 4. Habilitar Corepack (para Yarn y pnpm)
+
+[Corepack](https://nodejs.org/api/corepack.html) es una herramienta experimental incluida con Node.js que simplifica la gestión de diferentes gestores de paquetes. Con ella, no necesitas instalar [Yarn](https://yarnpkg.com/) o [pnpm](https://pnpm.io/) manualmente.
+
+Para habilitarlo, simplemente ejecuta:
+
+```bash
+sudo corepack enable
+```
+
+Ahora puedes usar `yarn` y `pnpm` en tus proyectos sin pasos de instalación adicionales.
+
+#### 5. Instalar Bun (opcional)
+
+[Bun](https://bun.sh/) es un toolkit de JavaScript todo en uno y muy rápido que está ganando mucha popularidad. Si quieres probarlo, puedes instalarlo con su script oficial:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+### El script
+
+Este es el script completo que automatiza los pasos anteriores. Incluye confirmaciones y gestiona los archivos temporales, haciendo que el proceso sea más cómodo y seguro.
+
+<!-- automd:file src="../../../public/scripts/ubuntu-install-node-24.sh" code lang="bash" -->
+
+```bash [ubuntu-install-node-24.sh]
+#!/bin/bash
+#
+# Author: Ángel Blanco
+# License: MIT
+#
+# This script is provided "as is", without warranty of any kind. Use at your own risk.
+#
+# Source: https://angelblanco.dev/blog/install-node-24-on-ubuntu-24
+#
+# Usage:
+#   curl -fsSL https://angelblanco.dev/scripts/ubuntu-install-node-24.sh | bash
+#
+# This file set up installation of Node JS and several package managers.
+# Normally you will call it from your non-root user, elevated permisson
+# will be granted with sudo.
+#
+
+set -e
+
+# Basic confirmation module before executing the script.
+confirm_action() {
+    read -p "$1 (y/n): " choice
+    case "$choice" in
+        [Yy]|[Yy][Ee][Ss])
+            return 0
+            ;;
+        [Nn]|[Nn][Oo])
+            return 1
+            ;;
+        *)
+            echo "Invalid choice. Please enter 'y' or 'n'."
+            confirm_action "$1"
+            ;;
+    esac
+}
+
+# You can configure this variables if needed
+NODE_VERSION=24
+NPM_PREFIX="~/.npm-global"
+DEPS="ca-certificates curl gnupg"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+TMP_DIR=$SCRIPT_DIR/tmp
+
+echo "This script will install Node.js and optionally other package managers."
+echo ""
+
+if ! confirm_action "Install Node.js version $NODE_VERSION?"; then
+    echo "Skipping Node.js installation. Exiting."
+    exit 0
+fi
+
+echo "Installing deps needed for installing node.js..."
+
+sudo apt update
+sudo apt install -y $DEPS
+
+echo "Installing node JS"
+mkdir -p $TMP_DIR
+curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x -o $TMP_DIR/nodesource_setup.sh
+sudo -E bash $TMP_DIR/nodesource_setup.sh
+
+sudo apt-get install -y nodejs
+
+mkdir -p ~/.npm-global
+npm config set prefix $NPM_PREFIX
+echo "Npm prefix set to $NPM_PREFIX"
+
+echo "Node.js installation completed."
+echo "Node version: "
+node --version
+
+echo ""
+
+if confirm_action "Enable Yarn and pnpm via corepack?"; then
+    echo "Enabling corepack..."
+    sudo corepack enable
+    echo "Corepack enabled."
+    echo "Yarn version: "
+    yarn --version
+    echo "PNPM version: "
+    pnpm --version
+fi
+
+echo ""
+
+if confirm_action "Install Bun?"; then
+    echo "Installing Bun..."
+    curl -fsSL https://bun.sh/install | bash
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    echo "Bun installation completed."
+    bun --version
+fi
+
+echo ""
+echo "Installation process finished."
+echo ""
+echo "You probably want to add global npm bin directory to your path on your .bashrc or .zshrc, to do so, include this line"
+echo 'export PATH=~/.npm-global/bin:$PATH'
+echo ""
+echo "If you wanto to remove the files downloaded in this process please execute"
+echo "rm -rf $TMP_DIR"
+```
+
+<!-- /automd -->
+
+### ¿Y qué hay de NVM?
+
+[Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) es una herramienta fantástica para gestionar múltiples versiones de Node.js. Sin embargo, personalmente prefiero mantenerme con una única instalación de la última versión LTS a nivel de sistema. Este enfoque me obliga a mantener mis proyectos actualizados. Además, Node.js no suele introducir grandes cambios disruptivos en sus versiones LTS, por lo que el proceso de actualización suele ser sencillo.
+
+Si prefieres la flexibilidad de NVM, puedes seguir usándolo, pero probablemente acabarías eligiendo un método u otro. Después de instalar NVM, gestionarías tus gestores de paquetes como `yarn` y `pnpm` instalándolos globalmente a través de `npm` para cada versión de Node que utilices. Podrías entonces usar alias para cambiar entre diferentes versiones de tus herramientas. Ten en cuenta que esto a veces puede llevar a conflictos de rutas o comportamientos inesperados, así que ten cuidado con qué versiones están activas en tu terminal.

--- a/apps/angelblanco.dev/package.json
+++ b/apps/angelblanco.dev/package.json
@@ -15,7 +15,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "cleanup": "nuxi cleanup"
+    "cleanup": "nuxi cleanup",
+    "automd": "automd"
   },
   "dependencies": {
     "@angelblanco/tailwind": "workspace:*",
@@ -51,6 +52,7 @@
     "@vue/test-utils": "^2.4.6",
     "@vueuse/core": "^13.9.0",
     "@vueuse/nuxt": "^13.9.0",
+    "automd": "^0.4.2",
     "better-sqlite3": "^12.4.1",
     "happy-dom": "^20.0.0",
     "nuxt": "^4.1.3",

--- a/apps/angelblanco.dev/public/scripts/ubuntu-install-node-24.sh
+++ b/apps/angelblanco.dev/public/scripts/ubuntu-install-node-24.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# Author: Ángel Blanco
+# License: MIT
+#
+# This script is provided "as is", without warranty of any kind. Use at your own risk.
+#
+# Source: https://angelblanco.dev/blog/install-node-24-on-ubuntu-24
+#
+# Usage:
+#   curl -fsSL https://angelblanco.dev/scripts/ubuntu-install-node-24.sh | bash
+#
+# This file set up installation of Node JS and several package managers.
+# Normally you will call it from your non-root user, elevated permisson
+# will be granted with sudo.
+#
+
+set -e
+
+# Basic confirmation module before executing the script.
+confirm_action() {
+    read -p "$1 (y/n): " choice
+    case "$choice" in
+        [Yy]|[Yy][Ee][Ss])
+            return 0
+            ;;
+        [Nn]|[Nn][Oo])
+            return 1
+            ;;
+        *)
+            echo "Invalid choice. Please enter 'y' or 'n'."
+            confirm_action "$1"
+            ;;
+    esac
+}
+
+# You can configure this variables if needed
+NODE_VERSION=24
+NPM_PREFIX="~/.npm-global"
+DEPS="ca-certificates curl gnupg"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+TMP_DIR=$SCRIPT_DIR/tmp
+
+echo "This script will install Node.js and optionally other package managers."
+echo ""
+
+if ! confirm_action "Install Node.js version $NODE_VERSION?"; then
+    echo "Skipping Node.js installation. Exiting."
+    exit 0
+fi
+
+echo "Installing deps needed for installing node.js..."
+
+sudo apt update
+sudo apt install -y $DEPS
+
+echo "Installing node JS"
+mkdir -p $TMP_DIR
+curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x -o $TMP_DIR/nodesource_setup.sh
+sudo -E bash $TMP_DIR/nodesource_setup.sh
+
+sudo apt-get install -y nodejs
+
+mkdir -p ~/.npm-global
+npm config set prefix $NPM_PREFIX
+echo "Npm prefix set to $NPM_PREFIX"
+
+echo "Node.js installation completed."
+echo "Node version: "
+node --version
+
+echo ""
+
+if confirm_action "Enable Yarn and pnpm via corepack?"; then
+    echo "Enabling corepack..."
+    sudo corepack enable
+    echo "Corepack enabled."
+    echo "Yarn version: "
+    yarn --version
+    echo "PNPM version: "
+    pnpm --version
+fi
+
+echo ""
+
+if confirm_action "Install Bun?"; then
+    echo "Installing Bun..."
+    curl -fsSL https://bun.sh/install | bash
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    echo "Bun installation completed."
+    bun --version
+fi
+
+echo ""
+echo "Installation process finished."
+echo ""
+echo "You probably want to add global npm bin directory to your path on your .bashrc or .zshrc, to do so, include this line"
+echo 'export PATH=~/.npm-global/bin:$PATH'
+echo ""
+echo "If you wanto to remove the files downloaded in this process please execute"
+echo "rm -rf $TMP_DIR"

--- a/packages/conventions/blog.md
+++ b/packages/conventions/blog.md
@@ -1,0 +1,51 @@
+# Blog Post Conventions
+
+This document outlines the conventions for writing and editing blog posts for angelblanco.dev. These guidelines are derived from the project's context and AI command configurations to ensure consistency and quality.
+
+## Guiding Principles
+
+### Audience & Tone
+
+- **Target Audience:** The primary audience is full-stack software developers.
+- **Tone:** Content should be professional yet approachable and engaging. The voice is that of a friendly, knowledgeable peer who explains complex topics clearly. A touch of humor is encouraged, but the content should not feel like a dry user manual.
+
+### SEO & Linking
+
+- To improve SEO and provide value, posts **must** include external links to relevant, high-authority sources.
+- When mentioning a technology, framework, or tool (e.g., Nuxt, Tailwind CSS), link to its official website or documentation.
+
+## Language & Translation
+
+All blog posts must have both an English and a Spanish version.
+
+- **Synchronization:** The core concepts, structure, and technical information must be consistent across both versions.
+- **Spanish Adaptation:** The Spanish post is **not** a literal translation. It must be an idiomatic adaptation for a tech audience from Spain (Castilian Spanish), ensuring it reads naturally.
+- **Technical Terminology:**
+  - Code blocks (` ``` `) must be identical in both posts and written in English.
+  - Common English technical terms (e.g., "commit", "deploy", "frontend") should be kept in English within the Spanish prose, as they are the industry standard.
+
+## Formatting
+
+- **Titles:** Markdown titles must use sentence case, not title case (e.g., `# My new blog post` instead of `# My New Blog Post`).
+- **Frontmatter:** All posts must include a valid YAML frontmatter block. See `GEMINI.md` for the schema.
+
+## Embedding File Content with `automd`
+
+To automatically embed and synchronize file content within a blog post, use the `automd` `file` generator. This is useful for keeping code examples or scripts up-to-date.
+
+### Usage
+
+To embed a code file, use the following syntax in your markdown, the file path must be relative to the markdown itself.
+The "code" attribute is needed to generate it as a code block. A comment with `\automd` is mandatory as closing tag for the replacement.
+
+```markdown
+<!-- automd:file src=".../...path/to/your/file.ts" code lang="ts"-->
+<!-- /automd -->
+```
+
+### Additional arguments
+
+- `src` (string): The relative path to the file you want to embed.
+- `lang` (string): The lang of the markdown file.
+- `code` (boolean): Render the file content within a code block.
+- `name` (string | boolean): Sets the file name displayed in the code block header. Use `no-name` to disable it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@vueuse/nuxt':
         specifier: ^13.9.0
         version: 13.9.0(magicast@0.3.5)(nuxt@4.1.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.7.1)(@vue/compiler-sfc@3.5.22)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.1)(lightningcss@1.30.1)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@24.7.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      automd:
+        specifier: ^0.4.2
+        version: 0.4.2(magicast@0.3.5)
       better-sqlite3:
         specifier: ^12.4.1
         version: 12.4.1
@@ -388,6 +391,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -2786,6 +2793,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  automd@0.4.2:
+    resolution: {integrity: sha512-9Gey0OG4gu2IzoLbwRj2fqyntJPbEFox/5KdOgg0zflkzq5lyOapWE324xYOvVdk9hgyjiMvDcT6XUPAIJhmag==}
+    hasBin: true
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3463,6 +3474,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  didyoumean2@7.0.4:
+    resolution: {integrity: sha512-+yW4SNY7W2DOWe2Jx5H4c2qMTFbLGM6wIyoDPkAPy66X+sD1KfYjBPAIWPVsYqMxelflaMQCloZDudELIPhLqA==}
+    engines: {node: ^18.12.0 || >=20.9.0}
+
   diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -3924,6 +3939,10 @@ packages:
   fast-xml-parser@5.3.0:
     resolution: {integrity: sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==}
     hasBin: true
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4737,6 +4756,9 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.deburr@4.1.0:
+    resolution: {integrity: sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -4814,6 +4836,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  md4w@0.2.7:
+    resolution: {integrity: sha512-lFM7vwk3d4MzkV2mija7aPkK6OjKXZDQsH2beX+e2cvccBoqc6RraheMtAO0Wcr/gjj5L+WS5zhb+06AmuGZrg==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -4852,6 +4877,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdbox@0.1.1:
+    resolution: {integrity: sha512-jvLISenzbLRPWWamTG3THlhTcMbKWzJQNyTi61AVXhCBOC+gsldNTUfUNH8d3Vay83zGehFw3wZpF3xChzkTIQ==}
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
@@ -7360,6 +7388,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -10100,6 +10130,28 @@ snapshots:
   asynckit@0.4.0:
     optional: true
 
+  automd@0.4.2(magicast@0.3.5):
+    dependencies:
+      '@parcel/watcher': 2.5.1
+      c12: 3.3.0(magicast@0.3.5)
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      didyoumean2: 7.0.4
+      magic-string: 0.30.19
+      mdbox: 0.1.1
+      mlly: 1.8.0
+      ofetch: 1.4.1
+      pathe: 2.0.3
+      perfect-debounce: 2.0.0
+      pkg-types: 2.3.0
+      scule: 1.3.0
+      tinyglobby: 0.2.15
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.3
@@ -10749,6 +10801,12 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  didyoumean2@7.0.4:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      fastest-levenshtein: 1.0.16
+      lodash.deburr: 4.1.0
+
   diff-sequences@27.5.1: {}
 
   diff@8.0.2: {}
@@ -11307,6 +11365,8 @@ snapshots:
   fast-xml-parser@5.3.0:
     dependencies:
       strnum: 2.1.1
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.19.1:
     dependencies:
@@ -12230,6 +12290,8 @@ snapshots:
   lodash.debounce@4.0.8:
     optional: true
 
+  lodash.deburr@4.1.0: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.escaperegexp@4.1.2: {}
@@ -12299,6 +12361,8 @@ snapshots:
 
   math-intrinsics@1.1.0:
     optional: true
+
+  md4w@0.2.7: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -12424,6 +12488,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdbox@0.1.1:
+    dependencies:
+      md4w: 0.2.7
 
   mdn-data@2.0.28: {}
 


### PR DESCRIPTION
✨ feat(blog): Add new blog post "Install Node.js 24 on Ubuntu 24"

This commit introduces a new blog post in both English and Spanish, detailing how to install Node.js 24 on Ubuntu 24.

Key changes include:
- **New Blog Post:** Added `0002.install-node-24-on-ubuntu-24.md` in both `content/blog` and `content/es/blog`.
- **`automd` Integration:** Configured `automd` in `apps/angelblanco.dev` to automatically embed the `ubuntu-install-node-24.sh` script into the blog posts. This involved:
    - Creating `apps/angelblanco.dev/automd.config.ts`.
    - Adding `automd` dependency and script to `apps/angelblanco.dev/package.json`.
    - Creating the `public/scripts/ubuntu-install-node-24.sh` script.
- **Refactor Blog Conventions:** Moved the detailed blog post conventions from `GEMINI.md` to a new dedicated file `packages/conventions/blog.md` for better organization and maintainability.
- **`refine.toml` Update:** Modified the `refine.toml` command to allow for more flexible argument passing for additional instructions during blog post refinement.
- **Documentation Update:** Updated `GEMINI.md` to reflect the new location of the blog post conventions and added a summary for the new `blog.md` convention file.